### PR TITLE
Extending init.js to support separate configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ If you have Galen Framework installed you can just checkout this project and run
 ```
 galen test tests/ --htmlreport reports
 ```
+
+
+Environments and SeleniumGrid
+=====================================
+
+You can create configurations for different environments, like local run, some cloud based service or just remote SeleniumGrid. Look at galen.hub.json as example how to configure it to use with remote SeleniumGrid instance.
+
+To run the defined configuration you have to specify GALEN_CONFIG as environment variable.
+
+```bash
+GALEN_CONFIG="galen.hub.json" galen test tests/ --htmlreport reports
+```
+
+By default `galen.local.json` configuration file will be used.

--- a/README.md
+++ b/README.md
@@ -11,16 +11,56 @@ If you have Galen Framework installed you can just checkout this project and run
 galen test tests/ --htmlreport reports
 ```
 
-
 Environments and SeleniumGrid
 =====================================
 
 You can create configurations for different environments, like local run, some cloud based service or just remote SeleniumGrid. Look at galen.hub.json as example how to configure it to use with remote SeleniumGrid instance.
 
-To run the defined configuration you have to specify GALEN_CONFIG as environment variable.
+To run the defined configuration you have to specify `GALEN_CONFIG` as environment variable.
 
 ```bash
 GALEN_CONFIG="galen.hub.json" galen test tests/ --htmlreport reports
 ```
 
+Configuration file
+=====================================
+
 By default `galen.local.json` configuration file will be used.
+
+In configuration file it's possible to define `domain` which galen should use as starting point, `gridUrl` in case you use remote Selenium Grid installation and `defaultBrowser`. 
+
+```javascript
+{
+	"domain" : "testapp.galenframework.com",
+	"gridUrl": "http://selenium-grid-url/hub/wd",
+	"defaultBrowser": "firefox"
+}
+```
+
+Also it's possible to keep all test-wide configuration information in this file
+under the key `config`. For example to keep test-user credentials.
+
+```javascript
+{
+	"config": {
+		"TEST_USER": {
+			"username": "testuser@example.com",
+			"password": "test123"
+		}
+	}
+}
+```
+
+Run only one test
+=====================================
+
+If you would like to run only one test of all of them, it's possible to specify
+it using only keyword. It might be useful when you have bunch of tests, but
+currently you're working only on one of them.
+
+Just prepend `.only` after `testOnAllDevices` or `testOnDevice` and you're good to
+go:
+
+```javascript
+testOnAllDevices.only("Login page", "/", function (driver, device) {});
+```

--- a/galen.hub.json
+++ b/galen.hub.json
@@ -1,0 +1,18 @@
+{
+	"domain" : "testapp.galenframework.com",
+	"gridUrl": "http://selenium-ip:4444/wd/hub",
+	"devices": {
+
+		"desktop" : {
+			"deviceName": "desktop",
+			"browser": "chrome",
+			"size": "1280x800",
+			"desiredCapabilities": {
+				"browser": "chrome",
+				"passed": "true",
+				"platform": "MAC",
+				"version": "43"
+			}
+		}
+	}
+}

--- a/galen.local.json
+++ b/galen.local.json
@@ -1,0 +1,31 @@
+{
+	"domain" : "testapp.galenframework.com",
+	"gridUrl": "",
+	"defaultBrowser": "firefox",
+	"devices" : {
+
+		"mobile": {
+			"deviceName": "mobile",
+			"size": "450x800",
+			"tags": ["mobile"]
+		},
+
+		"tablet": {
+			"deviceName": "tablet",
+			"size": "600x800",
+			"tags": ["tablet"]
+		},
+
+		"desktop": {
+			"deviceName": "desktop",
+			"size": "1100x800",
+			"tags": ["desktop"]
+		}
+	},
+	"config": {
+		"TEST_USER": {
+			"username": "testuser@example.com",
+			"password": "test123"
+		}
+	}
+}

--- a/tests/commons.js
+++ b/tests/commons.js
@@ -1,6 +1,8 @@
 load("pages/LoginPage.js");
 load("pages/MyNotesPage.js");
 
+var config = getConfig();
+
 function loginAsTestUser(driver) {
     new WelcomePage(driver)
         .waitForIt()
@@ -8,7 +10,7 @@ function loginAsTestUser(driver) {
 
     new LoginPage(driver)
         .waitForIt()
-        .loginAs(TEST_USER);
+        .loginAs(config.TEST_USER);
 
     return new MyNotesPage(driver).waitForIt();
 }


### PR DESCRIPTION
Added:
- Possibility to run on remote selenium-hub ( galen.hub.json as example )
- Added `.only` postfix to `testOnAllDevices` and `testOnDevice` functions
- Added Warning if requested device in `testOnDevice` is not found in configuration
- App-wide configuration support using getConfig() function
